### PR TITLE
步驟11: 任務列表以建立時間排序 + 調整 Enum 設定

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :find_params, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order(created_at: :desc)
     #未來會加上分頁功能
   end
 

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -4,6 +4,6 @@ module TasksHelper
   end
 
   def get_options_hash(col_name)
-    Task.send(col_name.pluralize)
+    Task.try(col_name.pluralize)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,9 @@
 module TasksHelper
+  def form_select_options(col_name)
+    get_options_hash(col_name).keys.map { |key| [ I18n.t("#{col_name}.#{key}"), key] }
+  end
+
+  def get_options_hash(col_name)
+    Task.send(col_name.pluralize)
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,6 @@ class Task < ApplicationRecord
   validates :priority, presence: true
   validates :status, presence: true
 
-  enum status: { ToDo: 0, Doing: 1, Done: 2 }
-  enum priority: { Low: 0, Mid: 1, High: 2 }
+  enum status: { todo: 0, doing: 1, done: 2 }
+  enum priority: { low: 0, mid: 1, high: 2 }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,14 +3,6 @@ class Task < ApplicationRecord
   validates :priority, presence: true
   validates :status, presence: true
 
-  enum status: { I18n.t("status.ToDo") => 0, I18n.t("status.Doing") => 1, I18n.t("status.Done") => 2 }
-  enum priority: { I18n.t("priority.low") => 0, I18n.t("priority.mid")=> 1, I18n.t("priority.high") => 2 }
-
-  def self.status_options
-    self.statuses.keys
-  end
-
-  def self.priority_options
-    self.priorities.keys
-  end
+  enum status: { ToDo: 0, Doing: 1, Done: 2 }
+  enum priority: { Low: 0, Mid: 1, High: 2 }
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -3,8 +3,8 @@
   <%= t("task.content.description") %>：<%= f.text_area :description %><br>
   <%= t("task.content.start_at") %>： <input type="datetime-local" name="task[start_at]"><br>
   <%= t("task.content.end_at") %>：<input type="datetime-local" name="task[end_at]"><br>
-  <%= t("task.content.status") %>：<%= f.select(:status, options_for_select( Task.status_options, [task.status]), prompt: 'Please Select') %><br>
-  <%= t("task.content.priority") %>：<%= f.select(:priority, options_for_select( Task.priority_options, [task.priority]), promot: 'Please Select') %><br>
+  <%= t("task.content.status") %>：<%= f.select(:status, options_for_select( form_select_options('status'), [task.status]), prompt: 'Please Select') %><br>
+  <%= t("task.content.priority") %>：<%= f.select(:priority, options_for_select( form_select_options('priority'), [task.priority]), promot: 'Please Select') %><br>
 
   <%= f.submit("#{action}") %><br>
   <%= link_to t("task.action.back"), root_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,19 +1,35 @@
 <h1><%= t("task.headline.list") %></h1>
 <%= link_to t("task.headline.new_task"), new_task_path %>
 
-<div>
-<% @tasks.each do |task| %><br>
-  <ul>
-    <li><%= t("task.content.title") %>：<%= link_to task.title, task_path(task) %></li><br>
-    <li><%= t("task.content.description") %>：<%= task.description %></li><br>
-    <li><%= t("task.content.start_at") %>：<%= task.start_at %></li><br>
-    <li><%= t("task.content.end_at") %>：<%= task.end_at %></li><br>
-    <li><%= t("task.content.status") %>：<%= t("status.#{task.status}") %></li><br>
-    <li><%= t("task.content.priority") %>：<%= t("priority.#{task.priority}") %></li><br>
-  </ul>
+<table>
+  <thead>
+    <tr>
+      <th><%= t("task.content.title") %></th>
+      <th><%= t("task.content.description") %></th>
+      <th><%= t("task.content.start_at") %></th>
+      <th><%= t("task.content.end_at") %></th>
+      <th><%= t("task.content.status") %></th>
+      <th><%= t("task.content.priority") %></th>
+    </tr>
+  </thead>
 
-  <%= link_to t("task.action.edit"), edit_task_path(task) %>
-  <%= link_to t("task.action.delete"), task_path(task), method: 'delete', data: {confirm: t("message.are_you_sure_to_delete", title: task.title) } %>
-<% end %>
-</div>
+  <tbody >
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= link_to task.title, task_path(task) %></td>
+        <td><%= task.description %></td>
+        <td><%= task.start_at %></td>
+        <td><%= task.end_at %></td>
+        <td><%= t("status.#{task.status}") %></td>
+        <td><%= t("priority.#{task.priority}") %></td>
+        <td><%= link_to t("task.action.edit"), edit_task_path(task) %></td>
+        <td><%= link_to t("task.action.delete"), task_path(task), method: 'delete', data: {confirm: t("message.are_you_sure_to_delete", title: task.title) } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+
+
+
 

--- a/config/locales/task_model.yml
+++ b/config/locales/task_model.yml
@@ -3,11 +3,11 @@
     attributes:
       task:
         statuses:
-          ToDo: 待處理
-          Doing: 進行中
-          Done: 已完成
+          todo: 待處理
+          doing: 進行中
+          done: 已完成
         priorities:
-          Low: 低
-          Mid: 中
-          High: 高
+          low: 低
+          mid: 中
+          high: 高
 

--- a/config/locales/task_model.yml
+++ b/config/locales/task_model.yml
@@ -2,10 +2,12 @@
   activerecord:
     attributes:
       task:
-        title: 任務名稱
-        description: 任務描述
-        start_at: 開始時間
-        end_at: 結束時間
-        status: 任務狀態
-        priority: 優先順序
+        statuses:
+          ToDo: 待處理
+          Doing: 進行中
+          Done: 已完成
+        priorities:
+          Low: 低
+          Mid: 中
+          High: 高
 

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -19,14 +19,14 @@
       delete: 刪除
   
   status:
-    ToDo: 待處理
-    Doing: 進行中
-    Done: 已完成
+    todo: 待處理
+    doing: 進行中
+    done: 已完成
   
   priority:
-    Low: 低
-    Mid: 中
-    High: 高
+    low: 低
+    mid: 中
+    high: 高
 
   message:
     create_success: 新增成功!

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -22,18 +22,11 @@
     ToDo: 待處理
     Doing: 進行中
     Done: 已完成
-    0: 待處理
-    1: 進行中
-    2: 已完成
   
   priority:
-    low: 低
-    mid: 中
-    high: 高
-    0: 低
-    1: 中
-    2: 高
-
+    Low: 低
+    Mid: 中
+    High: 高
 
   message:
     create_success: 新增成功!

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :task do
-    title { 'go jogging' }
-    description { 'run for a better life' }
-    status { 'ToDo' }
-    priority { 'High' }
+    title { 'title_1' }
+    description { 'description_1' }
+    status { 'todo' }
+    priority { 'high' }
     start_at { "#{ Time.zone.now }" }
     end_at { "#{ Time.zone.now + 1.day}" }
     deleted_at { nil }
@@ -11,8 +11,8 @@ FactoryBot.define do
     trait :newest_task do
       title { 'newest title' }
       description { 'newest description' }
-      status { 'Doing' }
-      priority { 'Mid' }
+      status { 'doing' }
+      priority { 'mid' }
     end
 
     trait :invalid_params do
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :update_params do
-      status { 'Doing' }
+      status { 'doing' }
     end
   end
 end 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -2,8 +2,8 @@ FactoryBot.define do
   factory :task do
     title { 'go jogging' }
     description { 'run for a better life' }
-    status { '待處理' }
-    priority { '高' }
+    status { 'ToDo' }
+    priority { 'High' }
     start_at { "#{ Time.zone.now }" }
     end_at { "#{ Time.zone.now + 1.day}" }
     deleted_at { nil }
@@ -11,8 +11,8 @@ FactoryBot.define do
     trait :newest_task do
       title { 'newest title' }
       description { 'newest description' }
-      status { '進行中' }
-      priority { '中' }
+      status { 'Doing' }
+      priority { 'Mid' }
     end
 
     trait :invalid_params do
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :update_params do
-      status { '進行中' }
+      status { 'Doing' }
     end
   end
 end 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -8,6 +8,13 @@ FactoryBot.define do
     end_at { "#{ Time.zone.now + 1.day}" }
     deleted_at { nil }
 
+    trait :newest_task do
+      title { 'newest title' }
+      description { 'newest description' }
+      status { '進行中' }
+      priority { '中' }
+    end
+
     trait :invalid_params do
       title { nil }
     end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -20,37 +20,44 @@ RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
       find("#task_priority").find(:xpath, "option[2]").select_option
       click_button "新增"
       
-      task = Task.last
+      task = Task.find(2)
 
       expect(current_path).to eq(root_path)
       expect(page).to have_text "新增成功!"
+      expect_task_contents_eq(
+        task, 
+        title: "task title", 
+        description: "task description", 
+        status: "ToDo", 
+        priority: "Mid"
+      )
       expect_task_attributes_eq(
         task, 
         title: "task title", 
         description: "task description", 
-        status: "待處理", 
-        priority: "中"
+        status: "ToDo", 
+        priority: "Mid"
       )
     end
 
     scenario "User reads the task" do
       visit root_path
-      task = Task.last
-      find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "#{task.title}").click
+      task = Task.find(1)
+      find(:xpath, "//a[@href='/tasks/1']", text: "go jogging").click
 
       expect_task_contents_eq(
         task, 
-        title: "#{task.title}", 
-        description: "#{task.description}", 
-        start_at: "#{task.start_at}", 
-        end_at: "#{task.end_at}", 
-        status: "#{task.status}", 
-        priority: "#{task.priority}" 
+        title: "go jogging", 
+        description: "run for a better life", 
+        start_at: task.start_at, 
+        end_at: task.end_at, 
+        status: "ToDo", 
+        priority: "High"
       )
     end
 
     scenario "User updates the task" do
-      task = Task.last
+      task = Task.find(1)
       visit task_path(task.id)
       click_button "編輯"
       fill_in "task[title]", with: "new title"
@@ -59,20 +66,20 @@ RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
 
       expect(current_path).to eq(task_path(task.id))
       expect(page).to have_text "更新成功!"
-      expect(page).to have_text("#{task.title}")
+      expect(page).to have_text("new title")
       expect(task.title).to eq "new title"
     end
 
     scenario "User deletes the task" do
       visit root_path
-      task = Task.last
-      find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "刪除").click
+      task = Task.find(1)
+      find(:xpath, "//a[@href='/tasks/1']", text: "刪除").click
       accept_alert(text: I18n.t("message.are_you_sure_to_delete", title: task.title))
   
       expect(current_path).to eq(root_path)
       expect(page).to have_text "已刪除!"
-      expect(page).to have_no_xpath("//a[@href='#{task_path(task.id)}']")
-      expect(Task.find_by(id: task.id)).to be_nil
+      expect(page).to have_no_xpath("//a[@href='/tasks/1']")
+      expect(Task.find_by(id: 1)).to be_nil
     end
   end
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -14,50 +14,50 @@ RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
       visit root_path
       click_link "新增任務"
       #輸入開始與結束時間，將於步驟14補測試
-      fill_in "task[title]", with: "task title"
-      fill_in "task[description]", with: "task description"
+      fill_in "task[title]", with: "title_2"
+      fill_in "task[description]", with: "description_2"
       find("#task_status").find(:xpath, "option[2]").select_option
       find("#task_priority").find(:xpath, "option[2]").select_option
       click_button "新增"
       
-      task = Task.find(2)
+      task = Task.find_by(title: "title_2", description: "description_2")
 
       expect(current_path).to eq(root_path)
-      expect(page).to have_text "新增成功!"
+      expect(page).to have_text("新增成功!")
       expect_task_contents_eq(
         task, 
-        title: "task title", 
-        description: "task description", 
-        status: "ToDo", 
-        priority: "Mid"
+        title: "title_2", 
+        description: "description_2", 
+        status: "todo", 
+        priority: "mid"
       )
       expect_task_attributes_eq(
         task, 
-        title: "task title", 
-        description: "task description", 
-        status: "ToDo", 
-        priority: "Mid"
+        title: "title_2", 
+        description: "description_2", 
+        status: "todo", 
+        priority: "mid"
       )
     end
 
     scenario "User reads the task" do
       visit root_path
-      task = Task.find(1)
-      find(:xpath, "//a[@href='/tasks/1']", text: "go jogging").click
+      task = Task.find_by(title: "title_1", description: "description_1")
+      find(:xpath, "//a[@href='/tasks/#{task.id}']", text: "title_1").click
 
       expect_task_contents_eq(
         task, 
-        title: "go jogging", 
-        description: "run for a better life", 
+        title: "title_1", 
+        description: "description_1", 
         start_at: task.start_at, 
         end_at: task.end_at, 
-        status: "ToDo", 
-        priority: "High"
+        status: "todo", 
+        priority: "high"
       )
     end
 
     scenario "User updates the task" do
-      task = Task.find(1)
+      task = Task.find_by(title: "title_1", description: "description_1")
       visit task_path(task.id)
       click_button "編輯"
       fill_in "task[title]", with: "new title"
@@ -65,21 +65,22 @@ RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
       task.reload
 
       expect(current_path).to eq(task_path(task.id))
-      expect(page).to have_text "更新成功!"
+      expect(page).to have_text("更新成功!")
       expect(page).to have_text("new title")
-      expect(task.title).to eq "new title"
+      expect(task.title).to eq("new title")
     end
 
     scenario "User deletes the task" do
       visit root_path
-      task = Task.find(1)
-      find(:xpath, "//a[@href='/tasks/1']", text: "刪除").click
-      accept_alert(text: I18n.t("message.are_you_sure_to_delete", title: task.title))
+      task = Task.find_by(title: "title_1", description: "description_1")
+      find(:xpath, "//a[@href='/tasks/#{task.id}']", text: "刪除").click
+      accept_alert(text: I18n.t("message.are_you_sure_to_delete", title: "title_1"))
   
       expect(current_path).to eq(root_path)
-      expect(page).to have_text "已刪除!"
-      expect(page).to have_no_xpath("//a[@href='/tasks/1']")
-      expect(Task.find_by(id: 1)).to be_nil
+      expect(page).to have_text("已刪除!")
+      expect(page).to have_no_xpath("//a[@href='/tasks/#{task.id}']")
+      expect(Task.find_by(id: task.id)).to be_nil
+
     end
   end
 
@@ -91,11 +92,11 @@ RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
       visit root_path
 
       within "tbody tr:nth-child(1)" do
-        expect(page).to have_text "new"
+        expect(page).to have_text("new")
       end
 
       within "tbody tr:nth-child(2)" do
-        expect(page).to have_text "old"
+        expect(page).to have_text("old")
       end
     end
   end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -7,71 +7,90 @@ end
 
 RSpec.feature "Tasks", driver: :selenium_chrome, js: true, type: :feature do
   
-  let(:task) { create(:task) }
+  context "Tasks CRUD" do
+    let!(:task) { create(:task) }
+
+    scenario "User creates a new task" do
+      visit root_path
+      click_link "新增任務"
+      #輸入開始與結束時間，將於步驟14補測試
+      fill_in "task[title]", with: "task title"
+      fill_in "task[description]", with: "task description"
+      find("#task_status").find(:xpath, "option[2]").select_option
+      find("#task_priority").find(:xpath, "option[2]").select_option
+      click_button "新增"
+      
+      task = Task.last
+
+      expect(current_path).to eq(root_path)
+      expect(page).to have_text "新增成功!"
+      expect_task_attributes_eq(
+        task, 
+        title: "task title", 
+        description: "task description", 
+        status: "待處理", 
+        priority: "中"
+      )
+    end
+
+    scenario "User reads the task" do
+      visit root_path
+      task = Task.last
+      find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "#{task.title}").click
+
+      expect_task_contents_eq(
+        task, 
+        title: "#{task.title}", 
+        description: "#{task.description}", 
+        start_at: "#{task.start_at}", 
+        end_at: "#{task.end_at}", 
+        status: "#{task.status}", 
+        priority: "#{task.priority}" 
+      )
+    end
+
+    scenario "User updates the task" do
+      task = Task.last
+      visit task_path(task.id)
+      click_button "編輯"
+      fill_in "task[title]", with: "new title"
+      click_button "更新"
+      task.reload
+
+      expect(current_path).to eq(task_path(task.id))
+      expect(page).to have_text "更新成功!"
+      expect(page).to have_text("#{task.title}")
+      expect(task.title).to eq "new title"
+    end
+
+    scenario "User deletes the task" do
+      visit root_path
+      task = Task.last
+      find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "刪除").click
+      accept_alert(text: I18n.t("message.are_you_sure_to_delete", title: task.title))
   
-  scenario "User creates a new task" do
-    visit root_path
-    click_link '新增任務'
-    #輸入開始與結束時間，將於步驟14補測試
-    fill_in 'task[title]', with: 'task title'
-    fill_in 'task[description]', with: 'task description'
-    find('#task_status').find(:xpath, 'option[2]').select_option
-    find('#task_priority').find(:xpath, 'option[2]').select_option
-    click_button '新增'
-    
-    task = Task.last
-
-    expect(current_path).to eq(root_path)
-    expect(page).to have_text '新增成功!'
-    expect_task_attributes_eq(
-      task, 
-      title: 'task title', 
-      description: 'task description', 
-      status: '待處理', 
-      priority: '中'
-    )
+      expect(current_path).to eq(root_path)
+      expect(page).to have_text "已刪除!"
+      expect(page).to have_no_xpath("//a[@href='#{task_path(task.id)}']")
+      expect(Task.find_by(id: task.id)).to be_nil
+    end
   end
 
-  scenario "User reads the task" do
-    visit root_path
-    task = Task.last
-    find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "#{task.title}").click
+  context "Tasks sort" do
+    let!(:old_task) { create(:task, title: "old", created_at:"2020-07-25 14:00:00") }
+    let!(:new_task) { create(:task, title: "new", created_at:"2020-07-26 14:00:00") }
 
-    expect_task_contents_eq(
-      task, 
-      title: "#{task.title}", 
-      description: "#{task.description}", 
-      start_at: "#{task.start_at}", 
-      end_at: "#{task.end_at}", 
-      status: "#{task.status}", 
-      priority: "#{task.priority}" 
-    )
-  end
+    scenario "User sees the newest task listed on the first post" do
+      visit root_path
 
-  scenario "User updates the task" do
-    task = Task.last
-    visit task_path(task.id)
-    click_button '編輯'
-    fill_in 'task[title]', with: 'new title'
-    click_button '更新'
-    task.reload
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_text "new"
+      end
 
-    expect(current_path).to eq(task_path(task.id))
-    expect(page).to have_text '更新成功!'
-    expect(page).to have_text("#{task.title}")
-    expect(task.title).to eq 'new title'
-  end
-
-  scenario "User deletes the task" do
-    visit root_path
-    task = Task.last
-    find(:xpath, "//a[@href='#{task_path(task.id)}']", text: "刪除").click
-    accept_alert(text: I18n.t("message.are_you_sure_to_delete", title: task.title))
-
-    expect(current_path).to eq(root_path)
-    expect(page).to have_text '已刪除!'
-    expect(page).to have_no_xpath("//a[@href='#{task_path(task.id)}']")
-    expect(Task.find_by(id: task.id)).to be_nil
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_text "old"
+      end
+    end
   end
 end
 

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "Tasks", type: :request do
   
   describe 'GET #index' do
     
-    it "should assign all tasks to @tasks" do
+    it "assigns all tasks to @tasks" do
       get tasks_path
       expect(assigns(:tasks)).to eq [task]
     end
   
-    it "should sort all tasks in descending order" do
+    it "sorts all tasks in descending order" do
       newest_task = create(:task, :newest_task)
       get tasks_path
       
@@ -24,14 +24,14 @@ RSpec.describe "Tasks", type: :request do
       expect(assigns(:tasks).last.created_at).to eq Task.minimum("created_at")
     end
 
-    it "should render the index template" do
+    it "renders the index template" do
       get tasks_path
       expect(response).to render_template("index")
     end
   end
 
   describe 'GET #new' do
-    it 'should assign a new task to @task ' do
+    it 'assigns a new task to @task ' do
       get new_task_path
       expect(assigns(:task)).to be_a_new(Task)
     end
@@ -41,30 +41,25 @@ RSpec.describe "Tasks", type: :request do
     context 'with valid params' do
       let!(:task) { build(:task) }
 
-      it 'should ensure title, status, priority presence' do
-        task = Task.new.save
-        expect(task).to eq false
-      end
-
-      it 'should create a task' do
+      it 'creates a task' do
         expect {
           post tasks_path, 
           params: { task: attributes_for(:task) }
         }.to change { Task.count }.by(1)
         
-        last_task = Task.last 
+        task = Task.last
         expect_task_attributes_eq(
-          last_task, 
-          title: "#{last_task.title}", 
-          description: 'run for a better life', 
+          task, 
+          title: "go jogging", 
+          description: "run for a better life", 
           start_at: "#{ Time.zone.now }",
           end_at: "#{ Time.zone.now + 1.day}",
-          status: '待處理', 
-          priority: '高'
+          status: "ToDo", 
+          priority: "High"
         )
       end
 
-      it 'should redirect to root path' do
+      it 'redirects to root path' do
         post tasks_path, params: { task: attributes_for(:task) }
         expect(response).to redirect_to root_path
         expect(flash[:notice]).to eq '新增成功!'
@@ -81,7 +76,7 @@ RSpec.describe "Tasks", type: :request do
               }.to change { Task.count }.by(0)
       end
 
-      it 'should render new template' do
+      it 'renders new template' do
         post tasks_path, params:  { task: attributes_for(:task, :invalid_params) }
         expect(response).to render_template("new")
       end
@@ -89,14 +84,14 @@ RSpec.describe "Tasks", type: :request do
   end
 
   describe 'GET #show' do
-    it "should assign a task to @task " do    
+    it "assigns a task to @task " do    
       get task_path(task)
       expect(assigns(:task)).to eq task
     end
   end
 
   describe 'GET #edit' do
-    it "should assign a task to @task " do
+    it "assigns a task to @task " do
       get edit_task_path(task)
       expect(assigns(:task)).to eq task
     end
@@ -107,13 +102,13 @@ RSpec.describe "Tasks", type: :request do
       let!(:update_task) { create(:task, :update_params) }
       let!(:new_status) { Task.find(update_task.id).status }
 
-      it 'should update one or more new attributes to @task' do      
+      it 'updates one or more new attributes to @task' do      
         put task_path(update_task), params: { task: attributes_for(:task, :update_params) }
         update_task.reload
         expect(update_task.status).to eq new_status
       end
 
-      it 'should redirect to show template' do
+      it 'redirects to show template' do
         put task_path(update_task), params: { task: attributes_for(:task, :update_params) }
         expect(response).to redirect_to task_path(update_task)
         expect(flash[:notice]).to eq '更新成功!'
@@ -122,7 +117,7 @@ RSpec.describe "Tasks", type: :request do
   end
 
   describe 'DELETE #destroy' do
-    it 'should delete @task' do
+    it 'deletes @task' do
       expect { delete task_path(task) }.to change { Task.count }.by(-1)
       expect(Task.count).to eq(0)
       
@@ -130,7 +125,7 @@ RSpec.describe "Tasks", type: :request do
       expect(delete_task).to be_nil
     end
 
-    it 'should redirect to index template' do      
+    it 'redirects to index template' do      
       delete task_path(task)                  
       expect(response).to redirect_to root_path
       expect(flash[:notice]).to eq '已刪除!'

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -7,12 +7,21 @@ end
 
 RSpec.describe "Tasks", type: :request do
 
-  let!(:task) { create(:task) }   
+  let!(:task) { create(:task) }
   
   describe 'GET #index' do
+    
     it "should assign all tasks to @tasks" do
       get tasks_path
       expect(assigns(:tasks)).to eq [task]
+    end
+  
+    it "should sort all tasks in descending order" do
+      newest_task = create(:task, :newest_task)
+      get tasks_path
+      
+      expect(assigns(:tasks).first.created_at).to eq Task.maximum("created_at")
+      expect(assigns(:tasks).last.created_at).to eq Task.minimum("created_at")
     end
 
     it "should render the index template" do
@@ -46,7 +55,7 @@ RSpec.describe "Tasks", type: :request do
         last_task = Task.last 
         expect_task_attributes_eq(
           last_task, 
-          title: 'go jogging', 
+          title: "#{last_task.title}", 
           description: 'run for a better life', 
           start_at: "#{ Time.zone.now }",
           end_at: "#{ Time.zone.now + 1.day}",

--- a/spec/requests/tasks_request_spec.rb
+++ b/spec/requests/tasks_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Tasks", type: :request do
     
     it "assigns all tasks to @tasks" do
       get tasks_path
-      expect(assigns(:tasks)).to eq [task]
+      expect(assigns(:tasks)).to eq([task])
     end
   
     it "sorts all tasks in descending order" do
@@ -47,22 +47,22 @@ RSpec.describe "Tasks", type: :request do
           params: { task: attributes_for(:task) }
         }.to change { Task.count }.by(1)
         
-        task = Task.last
+        task = Task.find_by(title: "title_1", description: "description_1")
         expect_task_attributes_eq(
           task, 
-          title: "go jogging", 
-          description: "run for a better life", 
+          title: "title_1", 
+          description: "description_1", 
           start_at: "#{ Time.zone.now }",
           end_at: "#{ Time.zone.now + 1.day}",
-          status: "ToDo", 
-          priority: "High"
+          status: "todo", 
+          priority: "high"
         )
       end
 
       it 'redirects to root path' do
         post tasks_path, params: { task: attributes_for(:task) }
         expect(response).to redirect_to root_path
-        expect(flash[:notice]).to eq '新增成功!'
+        expect(flash[:notice]).to eq("新增成功!")
       end
     end
 
@@ -86,14 +86,14 @@ RSpec.describe "Tasks", type: :request do
   describe 'GET #show' do
     it "assigns a task to @task " do    
       get task_path(task)
-      expect(assigns(:task)).to eq task
+      expect(assigns(:task)).to eq(task)
     end
   end
 
   describe 'GET #edit' do
     it "assigns a task to @task " do
       get edit_task_path(task)
-      expect(assigns(:task)).to eq task
+      expect(assigns(:task)).to eq(task)
     end
   end
 
@@ -105,13 +105,13 @@ RSpec.describe "Tasks", type: :request do
       it 'updates one or more new attributes to @task' do      
         put task_path(update_task), params: { task: attributes_for(:task, :update_params) }
         update_task.reload
-        expect(update_task.status).to eq new_status
+        expect(update_task.status).to eq(new_status)
       end
 
       it 'redirects to show template' do
         put task_path(update_task), params: { task: attributes_for(:task, :update_params) }
         expect(response).to redirect_to task_path(update_task)
-        expect(flash[:notice]).to eq '更新成功!'
+        expect(flash[:notice]).to eq("更新成功!")
       end
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe "Tasks", type: :request do
     it 'redirects to index template' do      
       delete task_path(task)                  
       expect(response).to redirect_to root_path
-      expect(flash[:notice]).to eq '已刪除!'
+      expect(flash[:notice]).to eq("已刪除!")
     end
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,10 +1,6 @@
 RSpec.configure do |config|
   
   config.before(:suite) do
-    if config.use_transactional_fixtures?
-      raise(<<-MSG)
-      MSG
-    end
     DatabaseCleaner.clean_with(:truncation)
   end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,17 +1,35 @@
 RSpec.configure do |config|
+  
   config.before(:suite) do
-    DatabaseCleaner.clean_with :truncation, except: %w(ar_internal_metadata)
+    if config.use_transactional_fixtures?
+      raise(<<-MSG)
+      MSG
+    end
+    DatabaseCleaner.clean_with(:truncation)
   end
 
   config.before(:each) do
     DatabaseCleaner.strategy = :transaction
   end
 
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    unless driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
   config.before(:each) do
     DatabaseCleaner.start
   end
 
-  config.after(:each) do
+  config.append_after(:each) do
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
#### 步驟11: 任務列表以建立時間排序
- 資料預設是以 id 進行排序，改以建立時間（created_at）排序
- 撰寫 feature spec
- 撰寫 request spec
- 調整 database_cleaner.rb：解決 `a spec and app-under-test do not share a database connection`([參考解法](https://github.com/DatabaseCleaner/database_cleaner#rspec-with-capybara-example))

#### 調整 Enum 設定
- 將 Enum hash key 由 I18n 表示方式調整為純英文
- 將 option_for_select 中的選項陣列抽成一個 method，並放在 task_helper 中


#### 調整 RSpec
- `it` 後方的描述將 `should` 改成第三人稱動詞
- 將 `Task.last` 調整為 `Task.find(1)`，讓測試的對象更具體，也可避免未來排序方式改變而影響到原本的測試對象